### PR TITLE
template_buyoffers optional on market_asset_object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/atomicassets",
     "description": "AtomicAsset library for Wharf",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "homepage": "https://github.com/wharfkit/atomicassets",
     "main": "lib/atomicassets.js",
     "module": "lib/atomicassets.m.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,7 +280,7 @@ export class MarketAssetObject extends AssetObject {
     @Struct.field(SaleBrief, {array: true}) declare sales: SaleBrief[]
     @Struct.field(AuctionBrief, {array: true}) declare auctions: AuctionBrief[]
     @Struct.field(AssetPriceV2, {array: true, optional: true}) declare prices: AssetPriceV2[]
-    @Struct.field(TemplateBuyofferBrief, {array: true})
+    @Struct.field(TemplateBuyofferBrief, {array: true, optional: true})
     declare template_buyoffers: TemplateBuyofferBrief[]
 }
 


### PR DESCRIPTION
Resolves error when template_buyoffers is not present on market_asset_object
![image](https://github.com/user-attachments/assets/4917f831-de49-4968-8585-be86c18e3878)

Version bumped to 1.2.2